### PR TITLE
image_url helper responds to fit and focus

### DIFF
--- a/lib/contentful/asset.rb
+++ b/lib/contentful/asset.rb
@@ -18,10 +18,12 @@ module Contentful
     # See https://www.contentful.com/developers/documentation/content-delivery-api/#image-asset-resizing
     def image_url(options = {})
       query = {
-        w:  options[:w]  || options[:width],
-        h:  options[:h]  || options[:height],
-        fm: options[:fm] || options[:format],
-        q:  options[:q]  || options[:quality]
+        w:   options[:w]  || options[:width],
+        h:   options[:h]  || options[:height],
+        fm:  options[:fm] || options[:format],
+        q:   options[:q]  || options[:quality],
+        f:   options[:f]  || options[:focus],
+        fit: options[:fit]
       }.reject { |_k, v| v.nil? }
 
       if query.empty?

--- a/spec/asset_spec.rb
+++ b/spec/asset_spec.rb
@@ -54,9 +54,9 @@ describe Contentful::Asset do
     end
 
     it 'adds image options if given' do
-      url = asset.image_url(width: 100, format: 'jpg', quality: 50)
+      url = asset.image_url(width: 100, format: 'jpg', quality: 50, focus: 'top_right', fit: 'thumb')
       expect(url).to include asset.file.url
-      expect(url).to include '?w=100&fm=jpg&q=50'
+      expect(url).to include '?w=100&fm=jpg&q=50&f=top_right&fit=thumb'
     end
   end
 end


### PR DESCRIPTION
The `fit` and `focus` parameters are useful for handling images. This would add them to the `image_url` method.
