### PR TITLE
Improve wording (rate limit chapter)

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ first_entry.fields('de-DE') # Returns German localizations
 ```
 
 ## Rate-limit
-The library does not make assumptions on the rate limit but reacts to `HTTP 429` by returning an error object.
+The library does not make assumptions on the rate limit but reacts to `HTTP 429` by raising or returning an error (see [Client Configuration Options](#client-configuration-options)).
 You should handle this within your code and either do the delay calculation naive (fixed amount of seconds) or more elaborated (exponential increase) depending by the structure of your code.
 
 


### PR DESCRIPTION
Hi,

I just stumbled upon the rate limit chapter and was asking myself if the gem actually __returns__ an object (like the 'normal' OOP flow) or __raises__ an error, which can be dealt with by rescuing etc pp.
This PR rewords the sentece slightly to be more explicit about.