### PR TITLE
Enable gzip encoding by default

### DIFF
--- a/lib/contentful/client.rb
+++ b/lib/contentful/client.rb
@@ -23,7 +23,7 @@ module Contentful
       entry_mapping: {},
       default_locale: 'en-US',
       raw_mode: false,
-      gzip_encoded: false,
+      gzip_encoded: true,
       logger: false,
       log_level: Logger::INFO,
       proxy_host: nil,


### PR DESCRIPTION
The README mentions this option should be enabled by default (which makes sense imo), but I just noticed this is not the case.