### PR TITLE
Add missing `zlib` import

### DIFF
--- a/lib/contentful/response.rb
+++ b/lib/contentful/response.rb
@@ -1,5 +1,6 @@
 require_relative 'error'
 require 'multi_json'
+require 'zlib'
 
 module Contentful
   # An object representing an answer by the contentful service. It is later used


### PR DESCRIPTION
Might be an OS X system ruby thing, but nevertheless seems right to avoid:

```bash
/Library/Ruby/Gems/2.0.0/gems/contentful-0.6.0/lib/contentful/response.rb:98:in `unzip_response': uninitialized constant Contentful::Response::Zlib (NameError)
``` 