### PR TITLE
Support for coercion via a Proc when providing one to `property`.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem 'listen', '3.0.6'
 
 group :documentation do
   gem 'coveralls', :require => false

--- a/lib/contentful/resource.rb
+++ b/lib/contentful/resource.rb
@@ -212,6 +212,8 @@ module Contentful
       case what
       when Symbol
         COERCIONS[what] ? COERCIONS[what][value] : value
+      when Proc
+        what[value]
       when Class
         what.new(value, client) if value
       else

--- a/lib/contentful/resource.rb
+++ b/lib/contentful/resource.rb
@@ -174,9 +174,7 @@ module Contentful
     end
 
     def coerce_value_or_array(value, what = nil)
-      if value.nil?
-        nil
-      elsif value.is_a? ::Array
+      if value.is_a? ::Array
         value.map { |v| coerce_or_create_class(v, what) }
       elsif should_coerce_hash?(value)
         ::Hash[value.map do |k, v|
@@ -215,7 +213,7 @@ module Contentful
       when Symbol
         COERCIONS[what] ? COERCIONS[what][value] : value
       when Class
-        what.new(value, client)
+        what.new(value, client) if value
       else
         value
       end

--- a/spec/coercions_spec.rb
+++ b/spec/coercions_spec.rb
@@ -16,8 +16,8 @@ describe 'Coercion Examples' do
     end
 
     it 'can use proc' do
-      cat = TestCar.new("parts" => nil)
-      expect(cat.parts).to be_empty
+      car = TestCar.new("parts" => nil)
+      expect(car.parts).to be_empty
     end
   end
 end

--- a/spec/coercions_spec.rb
+++ b/spec/coercions_spec.rb
@@ -7,4 +7,17 @@ describe 'Coercion Examples' do
     expect(entry.created_at).to be_a DateTime
     expect(entry.created_at.day).to eq 27
   end
+
+  describe 'custom coercion' do
+    class TestCar
+      include Contentful::Resource
+
+      property :parts, ->(v) { Array(v) unless v }
+    end
+
+    it 'can use proc' do
+      cat = TestCar.new("parts" => nil)
+      expect(cat.parts).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
I wanted to get rid of a `nil` returned where an empty list `[]` would have made sense. Reading the source code I eventually realized that this was impossible since somewhere in `Resource` a private method returns `nil` when a `value.nil?` is true. I made the smallest change possible for purpose of both supporting coercion via a Proc which would solve my issue.

Let me know what you think and thank you!