### PR TITLE
Bump HTTP gem to ~v1.0

### DIFF
--- a/contentful.gemspec
+++ b/contentful.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^spec/})
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'http', '~> 0.8'
+  gem.add_dependency 'http', '~> 1.0'
   gem.add_dependency 'multi_json', '~> 1'
   gem.add_dependency 'json', '~> 1.8'
 


### PR DESCRIPTION
We're in need of access to the Twitter gem, which uses ~v1.0 of the HTTP gem.

We've looked at http's changelog and noticed that they've only removed functionality ([here](https://github.com/httprb/http/blob/master/CHANGES.md#100-2015-12-25) and [here](https://github.com/httprb/http/blob/master/CHANGES.md#090-2015-07-23)). but that they aren't implemented features in this gem.