### PR TITLE
Removing unused `localized?` method.

### DIFF
--- a/lib/contentful/support.rb
+++ b/lib/contentful/support.rb
@@ -16,14 +16,6 @@ module Contentful
           .downcase
       end
 
-      # Returns true if resource is localized
-      #
-      # @return [true, false]
-      def localized?(value)
-        return false unless value.is_a? ::Hash
-        value.keys.any? { |possible_locale| Contentful::Constants::KNOWN_LOCALES.include?(possible_locale) }
-      end
-
       # Checks if value is a link
       #
       # @param value


### PR DESCRIPTION
This method looks to be referencing the KNOWN_LOCALES constant, which was removed as part of the recent updates.  I couldn't find this method being used anywhere, so I don't think it's needed anymore.