### PR TITLE
Fix for marshalling arrays that have "unresolved link" as first item

### DIFF
--- a/lib/contentful/entry.rb
+++ b/lib/contentful/entry.rb
@@ -63,7 +63,7 @@ module Contentful
     def known_link?(name)
       field_name = name.to_sym
       return true if known_contentful_object?(fields[field_name])
-      fields[field_name].is_a?(Enumerable) && known_contentful_object?(fields[field_name].first)
+      fields[field_name].is_a?(Enumerable) && fields[field_name].any? { |object| known_contentful_object?(object) }
     end
 
     def known_contentful_object?(object)


### PR DESCRIPTION
I noticed an issue (sort of edge case) when marshalling some of our objects.  Basically, we are trying to marshal an object that has a "has many" reference field called "items".  When that array is already hydrated, and the referenced objects all exist, then everything works fine. 
However, since the API also returns "Links" when we (accidentally) delete or unpublish one of the referenced entries, then marshalling doesn't fully resolve the associations because the `known_link?` method returns false if it's the first item in the array.

Example:

works when all associations exist and are published:
```
fields["items"]
#=> [ <Contentful::Entry[item] id='item1'>,
          <Contentful::Entry[item] id='item2'>,
          <Contentful::Entry[item] id='item3'>]
``` 

doesn't work when first entry removed/unpublished:
```
fields["items"]
#=> [ <Contentful::Link id='item1'>,
          <Contentful::Entry[item] id='item2'>,
          <Contentful::Entry[item] id='item3'>]
```

Proposed fix is to check to see if _any_ items in the array have already been resolved to known entry and, if so, then we can use the defined getter to retrieve it from `fields` instead of `raw['fields']`