### PR TITLE
Correctly support circular dependencies, bonus: 7.5x faster test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,12 +242,18 @@ Maximum time to wait for next available request (in seconds). Default value is 6
 can have up to 60 minutes of blocked requests. It is set to a default of 60 seconds in order to avoid blocking processes for too long, as rate limit retry behaviour
 is blocking per execution thread.
 
+### :reuse_entries
+
+When true, reuse hydrated Entry and Asset objects within the same request when possible. Can result in a large speed increase and better handles cyclical object graphs. 
+This can be a good alternative to `max_include_resolution_depth` if your content model contains (or can contain) circular references.
+
 ### :max_include_resolution_depth
 
 Maximum amount of levels to resolve includes for SDK entities (this is independent of API-level includes - it represents the maximum depth the include resolution
 tree is allowed to resolved before falling back to `Link` objects). This include resolution strategy is in place in order to avoid having infinite circular recursion
 on resources with circular dependencies. Defaults to 20. _Note_: If you're using something like `Rails::cache` it's advisable to considerably lower this value
 (around 5 has proven to be a good compromise - but keep it higher or equal than your maximum API-level include parameter if you need the entire tree resolution).
+Note that when `reuse_entries` is enabled, the max include resolution depth only affects deep chains of unique objects (ie, not simple circular references).
 
 ### :use_camel_case
 

--- a/lib/contentful/asset.rb
+++ b/lib/contentful/asset.rb
@@ -30,9 +30,13 @@ module Contentful
 
     def initialize(*)
       super
+    end
+
+    def hydrate(includes, entries)
+      super
       create_files!
       define_asset_methods!
-    end
+    end 
 
     # Generates a URL for the Contentful Image API
     #

--- a/lib/contentful/asset.rb
+++ b/lib/contentful/asset.rb
@@ -30,10 +30,6 @@ module Contentful
 
     def initialize(*)
       super
-    end
-
-    def hydrate(includes, entries)
-      super
       create_files!
       define_asset_methods!
     end

--- a/lib/contentful/asset.rb
+++ b/lib/contentful/asset.rb
@@ -36,7 +36,7 @@ module Contentful
       super
       create_files!
       define_asset_methods!
-    end 
+    end
 
     # Generates a URL for the Contentful Image API
     #

--- a/lib/contentful/base_resource.rb
+++ b/lib/contentful/base_resource.rb
@@ -5,6 +5,7 @@ module Contentful
   class BaseResource
     attr_reader :raw, :default_locale, :sys
 
+    # rubocop:disable Style/ParameterLists
     def initialize(item, configuration = {}, _localized = false, _includes = [], entries = {}, depth = 0)
       entries["#{item['sys']['type']}:#{item['sys']['id']}"] = self if entries && item.key?('sys')
       @raw = item

--- a/lib/contentful/base_resource.rb
+++ b/lib/contentful/base_resource.rb
@@ -5,8 +5,8 @@ module Contentful
   class BaseResource
     attr_reader :raw, :default_locale, :sys
 
-    def initialize(item, configuration = {}, _localized = false, _includes = [], _entries = {}, depth = 0)
-      _entries["#{item['sys']['type']}:#{item['sys']['id']}"] = self if _entries && item.key?('sys')
+    def initialize(item, configuration = {}, _localized = false, _includes = [], entries = {}, depth = 0)
+      entries["#{item['sys']['type']}:#{item['sys']['id']}"] = self if entries && item.key?('sys')
       @raw = item
       @default_locale = configuration[:default_locale]
       @depth = depth

--- a/lib/contentful/base_resource.rb
+++ b/lib/contentful/base_resource.rb
@@ -15,6 +15,9 @@ module Contentful
       define_sys_methods!
     end
 
+    def hydrate(includes, entries)
+    end
+
     # @private
     def inspect
       "<#{repr_name} id='#{sys[:id]}'>"

--- a/lib/contentful/base_resource.rb
+++ b/lib/contentful/base_resource.rb
@@ -5,7 +5,8 @@ module Contentful
   class BaseResource
     attr_reader :raw, :default_locale, :sys
 
-    def initialize(item, configuration = {}, _localized = false, _includes = [], depth = 0)
+    def initialize(item, configuration = {}, _localized = false, _includes = [], _entries = {}, depth = 0)
+      _entries["#{item['sys']['type']}:#{item['sys']['id']}"] = self if _entries && item.key?('sys')
       @raw = item
       @default_locale = configuration[:default_locale]
       @depth = depth
@@ -13,9 +14,6 @@ module Contentful
       @sys = hydrate_sys
 
       define_sys_methods!
-    end
-
-    def hydrate(includes, entries)
     end
 
     # @private

--- a/lib/contentful/entry.rb
+++ b/lib/contentful/entry.rb
@@ -15,9 +15,9 @@ module Contentful
 
     private
 
-    def coerce(field_id, value, includes)
-      return build_nested_resource(value, includes) if Support.link?(value)
-      return coerce_link_array(value, includes) if Support.link_array?(value)
+    def coerce(field_id, value, includes, entries = {})
+      return build_nested_resource(value, includes, entries) if Support.link?(value)
+      return coerce_link_array(value, includes, entries) if Support.link_array?(value)
 
       content_type_key = Support.snakify('contentType', @configuration[:use_camel_case])
       content_type = ContentTypeCache.cache_get(sys[:space].id, sys[content_type_key.to_sym].id)
@@ -27,13 +27,13 @@ module Contentful
         return content_type_field.coerce(value) unless content_type_field.nil?
       end
 
-      super(field_id, value, includes)
+      super(field_id, value, includes, entries)
     end
 
-    def coerce_link_array(value, includes)
+    def coerce_link_array(value, includes, entries)
       items = []
       value.each do |link|
-        items << build_nested_resource(link, includes)
+        items << build_nested_resource(link, includes, entries)
       end
 
       items
@@ -43,16 +43,16 @@ module Contentful
     # in case one of the included items has a reference in an upper level,
     # so we can keep the include chain for that object as well
     # Any included object after the maximum include resolution depth will be just a Link
-    def build_nested_resource(value, includes)
+    def build_nested_resource(value, includes, entries)
       if @depth < @configuration.fetch(:max_include_resolution_depth, 20)
         resource = Support.resource_for_link(value, includes)
-        return resolve_include(resource, includes) unless resource.nil?
+        return resolve_include(resource, includes, entries) unless resource.nil?
       end
 
       build_link(value)
     end
 
-    def resolve_include(resource, includes)
+    def resolve_include(resource, includes, entries)
       require_relative 'resource_builder'
 
       ResourceBuilder.new(
@@ -63,7 +63,8 @@ module Contentful
         ),
         localized,
         @depth + 1,
-        includes
+        includes,
+        entries
       ).run
     end
 

--- a/lib/contentful/entry.rb
+++ b/lib/contentful/entry.rb
@@ -59,12 +59,12 @@ module Contentful
         resource,
         @configuration.merge(
           includes_for_single:
-            @configuration.fetch(:includes_for_single, []) + includes
+            @configuration.fetch(:includes_for_single, []) + includes,
+          _entries_cache: entries
         ),
         localized,
         @depth + 1,
-        includes,
-        entries
+        includes
       ).run
     end
 

--- a/lib/contentful/fields_resource.rb
+++ b/lib/contentful/fields_resource.rb
@@ -6,6 +6,7 @@ module Contentful
   class FieldsResource < BaseResource
     attr_reader :localized
 
+    # rubocop:disable Style/ParameterLists
     def initialize(item, _configuration, localized = false, includes = [], entries = {}, *)
       super
 

--- a/lib/contentful/fields_resource.rb
+++ b/lib/contentful/fields_resource.rb
@@ -6,14 +6,10 @@ module Contentful
   class FieldsResource < BaseResource
     attr_reader :localized
 
-    def initialize(item, _configuration, localized = false, includes = [], *)
+    def initialize(item, _configuration, localized = false, includes = [], entries = {}, *)
       super
 
       @localized = localized
-      hydrate(includes, nil) if includes != 'skip'
-    end
-
-    def hydrate(includes, entries)
       @fields = hydrate_fields(includes, entries)
       define_fields_methods!
     end

--- a/lib/contentful/fields_resource.rb
+++ b/lib/contentful/fields_resource.rb
@@ -10,10 +10,13 @@ module Contentful
       super
 
       @localized = localized
-      @fields = hydrate_fields(includes)
-
-      define_fields_methods!
+      hydrate(includes, nil) if includes != 'skip'
     end
+
+    def hydrate(includes, entries)
+      @fields = hydrate_fields(includes, entries)
+      define_fields_methods!
+    end 
 
     # Returns all fields of the asset
     #
@@ -56,7 +59,7 @@ module Contentful
     def marshal_load(raw_object)
       super(raw_object)
       @localized = raw_object[:localized]
-      @fields = hydrate_fields(raw_object[:configuration].fetch(:includes_for_single, []))
+      @fields = hydrate_fields(raw_object[:configuration].fetch(:includes_for_single, []), {})
       define_fields_methods!
     end
 
@@ -82,7 +85,7 @@ module Contentful
       end
     end
 
-    def hydrate_fields(includes)
+    def hydrate_fields(includes, entries)
       return {} unless raw.key?('fields')
 
       locale = internal_resource_locale
@@ -96,7 +99,8 @@ module Contentful
             result[loc][name.to_sym] = coerce(
               name,
               value,
-              includes
+              includes,
+              entries
             )
           end
         end
@@ -106,7 +110,8 @@ module Contentful
           result[locale][name.to_sym] = coerce(
             name,
             value,
-            includes
+            includes,
+            entries
           )
         end
       end
@@ -116,7 +121,7 @@ module Contentful
 
     protected
 
-    def coerce(_field_id, value, _includes)
+    def coerce(_field_id, value, _includes, _entries)
       value
     end
   end

--- a/lib/contentful/resource_builder.rb
+++ b/lib/contentful/resource_builder.rb
@@ -75,7 +75,7 @@ module Contentful
       fail UnparsableResource, 'Item type is not known, could not parse' if item_type.nil?
       item_class = resource_class(item)
 
-      reuse_entries = @configuration.fetch(:reuse_entries, true)
+      reuse_entries = @configuration.fetch(:reuse_entries, false)
       entries = @entries ? @entries : {}
 
       id = "#{item['sys']['type']}:#{item['sys']['id']}"

--- a/lib/contentful/resource_builder.rb
+++ b/lib/contentful/resource_builder.rb
@@ -79,11 +79,11 @@ module Contentful
       entries = @entries ? @entries : {}
 
       id = "#{item['sys']['type']}:#{item['sys']['id']}"
-      if reuse_entries && entries.key?(id)
-        entry = entries[id]
-      else
-        entry = item_class.new(item, @configuration, localized?, includes, entries, depth)
-      end
+      entry = if reuse_entries && entries.key?(id)
+                entries[id]
+              else
+                item_class.new(item, @configuration, localized?, includes, entries, depth)
+              end
 
       entry
     end

--- a/lib/contentful/resource_builder.rb
+++ b/lib/contentful/resource_builder.rb
@@ -75,7 +75,7 @@ module Contentful
       fail UnparsableResource, 'Item type is not known, could not parse' if item_type.nil?
       item_class = resource_class(item)
 
-      reuse_entries = @configuration.fetch(:reuse_entries, false)
+      reuse_entries = @configuration.fetch(:reuse_entries, true)
       #reuse_entries = true
       entries = @entries ? @entries : {}
 

--- a/lib/contentful/resource_builder.rb
+++ b/lib/contentful/resource_builder.rb
@@ -78,18 +78,11 @@ module Contentful
       reuse_entries = @configuration.fetch(:reuse_entries, true)
       entries = @entries ? @entries : {}
 
-      if reuse_entries
-        id = "#{item['sys']['type']}:#{item['sys']['id']}"
-        if !entries.key?(id)
-          entry = item_class.new(item, @configuration, localized?, 'skip', depth)
-          entries[id] = entry
-          entry.hydrate(includes, entries)
-        else
-          entry = entries[id]
-        end
+      id = "#{item['sys']['type']}:#{item['sys']['id']}"
+      if reuse_entries && entries.key?(id)
+        entry = entries[id]
       else
-        entry = item_class.new(item, @configuration, localized?, 'skip', depth)
-        entry.hydrate(includes, entries)
+        entry = item_class.new(item, @configuration, localized?, includes, entries, depth)
       end
 
       entry


### PR DESCRIPTION
This changeset introduces a new option, enabled by default, called `reuse_entries`. When enabled, the gem will reuse Entry/Asset objects constructed during the current hydration cycle. This means if a request has cyclical relationships, only one object per type/ID is hydrated and that object is reused in the appropriate place in the dependency graph.

This changeset improves the woes expressed in #124 and elsewhere.

This change makes the previous `max_include_resolution_depth` configuration setting useful only for genuinely deep object structures, where there are a large amount of _unique_ objects within the request. 

Although I haven't done the work for it in this PR, I think the `max_include_resolution_depth` test fixtures should be changed to use a flat depth structure and not a cyclical one as the `nyancat` fixture is currently, as `reuse_entries` makes those tests fail because the gem never needs to use a ContentfulLink to represent links which are too deep (it just reuses the existing Entry instead). I think the flag still has value but it would no longer come into play for cyclical structures. So for those tests specifically I have used `reuse_entries: false` in the `create_client` calls which maintains the coverage of that feature without having `reuse_entries` interfere.

As a side note, I experienced very high amounts of time hydrating a cyclical structure within our test Contentful database (which contains a design our product team is building) even with `max_include_resolution_depth: 3`. In my tests none of the hydrations ever finished, instead memory usage just kept growing. I believe this may be related to an Asset being attached to one or both of the content objects which link to each other. Perhaps the `@depth` value inspected by `ResourceBuilder` are getting cleared when an `Asset` is involved in the hydration process. You may want to expand the test cases around this related to the `max_include_resolution_depth` configuration setting. 

With my change however, that problem is a non-issue as `max_include_resolution_depth` is not needed to prevent runaway hydration times.

As a bonus, because the library is not hydrating more copies of objects than necessary, the entire test suite is running about 7.5x faster (30 seconds without the feature enabled to 4 seconds with it enabled). 


