### PR TITLE
NoMethodError when nodes are coerced more then once in a request

### DIFF
--- a/lib/contentful/coercions.rb
+++ b/lib/contentful/coercions.rb
@@ -150,7 +150,8 @@ module Contentful
 
     def coerce_link(node, configuration)
       return node unless node.key?('data') && node['data'].key?('target')
-      return node unless node['data']['target'].is_a?(Hash) && node['data']['target']['sys']['type'] == 'Link'
+      return node['data']['target'] unless node['data']['target'].is_a?(Hash)
+      return node unless node['data']['target']['sys']['type'] == 'Link'
 
       return nil if Support.unresolvable?(node['data']['target'], configuration[:errors])
 

--- a/lib/contentful/coercions.rb
+++ b/lib/contentful/coercions.rb
@@ -150,7 +150,7 @@ module Contentful
 
     def coerce_link(node, configuration)
       return node unless node.key?('data') && node['data'].key?('target')
-      return node unless node['data']['target']['sys']['type'] == 'Link'
+      return node unless node['data']['target'].is_a?(Hash) && node['data']['target']['sys']['type'] == 'Link'
 
       return nil if Support.unresolvable?(node['data']['target'], configuration[:errors])
 


### PR DESCRIPTION
We've bumped into a bug with rich text coercion in instances where a request includes multiple links to the same entity, for example:

We have a `page` with a reference to a `textBlock` which has a rich text field linking back to the same instance of `page`.

This throws an error:
```
NoMethodError (undefined method `[]' for <Contentful::Page[page] id='...'>:Contentful::Page):
contentful (2.11.0) lib/contentful/entry.rb:96:in `method_missing'
contentful (2.11.0) lib/contentful/coercions.rb:153:in `coerce_link'
contentful (2.11.0) lib/contentful/coercions.rb:128:in `block in coerce_block'
contentful (2.11.0) lib/contentful/coercions.rb:126:in `each'
contentful (2.11.0) lib/contentful/coercions.rb:126:in `each_with_index'
contentful (2.11.0) lib/contentful/coercions.rb:126:in `coerce_block'
contentful (2.11.0) lib/contentful/coercions.rb:136:in `block in coerce_block'
contentful (2.11.0) lib/contentful/coercions.rb:126:in `each'
contentful (2.11.0) lib/contentful/coercions.rb:126:in `each_with_index'
contentful (2.11.0) lib/contentful/coercions.rb:126:in `coerce_block'
contentful (2.11.0) lib/contentful/coercions.rb:106:in `coerce'
...
```

This is because when the link in the rich text is coerced, the `['target']` has already been converted to a Page model and so the guard clause fails.

I believe this pull request fixes the issue.

I would like to add a test for this case with this PR, but I don't know how as an external contributor I can add new VCR cassettes without access to the contentful space that is used for testing. Happy to add if you can tell me how 😄