### PR TITLE
Cut some memory allocations

### DIFF
--- a/lib/contentful/base_resource.rb
+++ b/lib/contentful/base_resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'support'
 
 module Contentful

--- a/lib/contentful/base_resource.rb
+++ b/lib/contentful/base_resource.rb
@@ -65,12 +65,15 @@ module Contentful
       end
     end
 
+    LINKS = %w[space contentType environment].freeze
+    TIMESTAMPS = %w[createdAt updatedAt deletedAt].freeze
+
     def hydrate_sys
       result = {}
       raw.fetch('sys', {}).each do |k, v|
-        if %w[space contentType environment].include?(k)
+        if LINKS.include?(k)
           v = build_link(v)
-        elsif %w[createdAt updatedAt deletedAt].include?(k)
+        elsif TIMESTAMPS.include?(k)
           v = DateTime.parse(v)
         end
         result[Support.snakify(k, @configuration[:use_camel_case]).to_sym] = v

--- a/lib/contentful/fields_resource.rb
+++ b/lib/contentful/fields_resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'support'
 require_relative 'base_resource'
 

--- a/lib/contentful/support.rb
+++ b/lib/contentful/support.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Contentful
   # Utility methods used by the contentful gem
   module Support


### PR DESCRIPTION
I tracked down some excessive memory allocations (using the awesome [memory_profiler](https://github.com/SamSaffron/memory_profiler) gem from Sam Saffron) to our usage of the contentful gem.

These should all be quite safe changes, though less impactful if you have frozen string literals enabled globally (which we do not, and I imagine most people will not).

Using a simple test of:
```ruby
MemoryProfiler.report { client.entries(content_type: 'myEntryHere', include: 2) }.pretty_print
```

The allocations before/after this change look like:

## Before

```
allocated objects by class
-----------------------------------
    586613  String
     50510  Proc
     46370  Array
     43179  Hash
     25330  MatchData
      4394  Class
      4384  Rational
      2805  Contentful::Link

allocated objects by location
-----------------------------------
    100426  contentful.rb/lib/contentful/support.rb:17
     89836  contentful.rb/lib/contentful/support.rb:18
     76111  contentful.rb/vendor/bundle/gems/json-2.2.0/lib/json/common.rb:156
     71188  contentful.rb/lib/contentful/base_resource.rb:69
```

## After
```
allocated objects by class
-----------------------------------
    333595  String
     50510  Proc
     43179  Hash
     25330  MatchData
     13581  Array
      4394  Class
      4384  Rational
      2805  Contentful::Link

allocated objects by location
-----------------------------------
     76111  contentful.rb/vendor/bundle/gems/json-2.2.0/lib/json/common.rb:1
     73592  contentful.rb/lib/contentful/support.rb:19
     61398  contentful.rb/lib/contentful/base_resource.rb:77
     39496  contentful.rb/lib/contentful/base_resource.rb:62
     36168  contentful.rb/lib/contentful/support.rb:20
```