### PR TITLE
Don't redefine existing methods in subclasses

### DIFF
--- a/lib/contentful/base_resource.rb
+++ b/lib/contentful/base_resource.rb
@@ -59,9 +59,7 @@ module Contentful
 
     def define_sys_methods!
       @sys.each do |k, v|
-        define_singleton_method k do
-          v
-        end
+        define_singleton_method(k) { v } unless self.class.method_defined?(k)
       end
     end
 

--- a/lib/contentful/fields_resource.rb
+++ b/lib/contentful/fields_resource.rb
@@ -83,9 +83,7 @@ module Contentful
 
     def define_fields_methods!
       fields.each do |k, v|
-        define_singleton_method k do
-          v
-        end
+        define_singleton_method(k) { v } unless self.class.method_defined?(k)
       end
     end
 

--- a/spec/entry_spec.rb
+++ b/spec/entry_spec.rb
@@ -3,6 +3,19 @@ require 'spec_helper'
 describe Contentful::Entry do
   let(:entry) { vcr('entry') { create_client.entry 'nyancat' } }
 
+  let(:subclass) do
+    Class.new(described_class) do
+      # An overridden sys method:
+      def created_at; 'yesterday'; end
+
+      # An overridden field method:
+      def best_friend; 'octocat'; end
+    end
+  end
+
+  let(:raw) { entry.raw }
+  let(:subclassed_entry) { subclass.new(raw, create_client.configuration) }
+
   describe 'SystemProperties' do
     it 'has a #sys getter returning a hash with symbol keys' do
       expect(entry.sys).to be_a Hash
@@ -36,6 +49,12 @@ describe Contentful::Entry do
     it 'has #revision' do
       expect(entry.revision).to eq 5
     end
+
+    context 'when subclassed' do
+      it 'does not redefine existing methods' do
+        expect(subclassed_entry.created_at).to eq 'yesterday'
+      end
+    end
   end
 
   describe 'Fields' do
@@ -47,6 +66,12 @@ describe Contentful::Entry do
     it "contains the entry's fields" do
       expect(entry.fields[:color]).to eq 'rainbow'
       expect(entry.fields[:best_friend]).to be_a Contentful::Entry
+    end
+
+    context 'when subclassed' do
+      it 'does not redefine existing methods' do
+        expect(subclassed_entry.best_friend).to eq 'octocat'
+      end
     end
   end
 


### PR DESCRIPTION
There are cases where I want to add some syntactic sugar to my content models but I've run into an issue where my subclasses are having their methods redefined to return the values of Contentful fields. Take for example an everyday occurrence in ActiveRecord:

```ruby
def some_field
  value = read_attribute(:some_field)
  # [some code manipulating that value]
  value
end
```

This PR adds a check for existing methods, skipping fields that have already been defined in subclasses.

---

**Edit:** I think I should add that it's kind of worrisome to think that this gem can silently wipe out our application logic whenever the Contentful API returns a field with the same name.