### PR TITLE
Ability to delegate multiple arguments to Array#[]

### DIFF
--- a/lib/contentful/array_like.rb
+++ b/lib/contentful/array_like.rb
@@ -37,8 +37,8 @@ module Contentful
     # Delegates to items#[]
     #
     # @return [Contentful::Entry, Contentful::Asset]
-    def [](index)
-      items[index]
+    def [](*args)
+      items[*args]
     end
 
     # Delegates to items#last

--- a/spec/array_spec.rb
+++ b/spec/array_spec.rb
@@ -36,6 +36,16 @@ describe Contentful::Array do
     end
   end
 
+  describe '#[]' do
+    it 'provides access to items by index' do
+      expect(array[0]).to be_a Contentful::BaseResource
+    end
+
+    it 'provides access to items by two indices' do
+      expect(array[0, 4]).to eq array.items
+    end
+  end
+
   describe '#each' do
     it 'is an Enumerator' do
       expect(array.each).to be_a Enumerator


### PR DESCRIPTION
`Array#[]` can accept two arguments to return a slice. This change makes `ArrayLike#[]` delegate all arguments to the underlying items array. I stumbled on this issue when trying to paginate `ArrayLike` collection using kaminari, which calls `Array#[]` with multiple arguments. 