### PR TITLE
consistent terminology [library-1766]

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@
   </a>
 </p>
 
-# contentful.rb - Contentful Ruby Delivery SDK
+# contentful.rb - Contentful Ruby Delivery Library
 [![Gem Version](https://badge.fury.io/rb/contentful.png)](http://badge.fury.io/rb/contentful)
 
-> Ruby SDK for the Contentful [Content Delivery API](https://www.contentful.com/developers/docs/references/content-delivery-api/) and [Content Preview API](https://www.contentful.com/developers/docs/references/content-preview-api/). It helps you to easily access your Content stored in Contentful with your Ruby applications.
+> Ruby library for the Contentful [Content Delivery API](https://www.contentful.com/developers/docs/references/content-delivery-api/) and [Content Preview API](https://www.contentful.com/developers/docs/references/content-preview-api/). It helps you to easily access your Content stored in Contentful with your Ruby applications.
 
 <p align="center">
   <img src="https://img.shields.io/badge/Status-Maintained-green.svg" alt="This repository is actively maintained" /> &nbsp;
@@ -45,12 +45,12 @@
 
 <!-- TOC -->
 
-- [contentful.rb - Contentful Ruby Delivery SDK](#contentfulrb---contentful-ruby-delivery-sdk)
+- [contentful.rb - Contentful Ruby Delivery library](#contentfulrb---contentful-ruby-delivery-library)
   - [Core Features](#core-features)
   - [Getting started](#getting-started)
     - [Installation](#installation)
     - [Your first request](#your-first-request)
-    - [Using this SDK with the Preview API](#using-this-sdk-with-the-preview-api)
+    - [Using this library with the Preview API](#using-this-library-with-the-preview-api)
     - [Authentication](#authentication)
   - [Documentation & References](#documentation--references)
     - [Configuration](#configuration)
@@ -94,11 +94,11 @@
 
 ## Getting started
 
-In order to get started with the Contentful Ruby SDK you'll need not only to install it, but also to get credentials which will allow you to have access to your content in Contentful.
+In order to get started with the Contentful Ruby library you'll need not only to install it, but also to get credentials which will allow you to have access to your content in Contentful.
 
 - [Installation](#installation)
 - [Your first request](#your-first-request)
-- [Using this SDK with the Preview API](#using-this-sdk-with-the-preview-api)
+- [Using this library with the Preview API](#using-this-library-with-the-preview-api)
 - [Authentication](#authentication)
 - [Documentation & References](#documentation--references)
 
@@ -118,7 +118,7 @@ gem i contentful
 
 ### Your first request
 
-The following code snippet is the most basic one you can use to get some content from Contentful with this SDK:
+The following code snippet is the most basic one you can use to get some content from Contentful with this library:
 
 ```ruby
 require 'contentful'
@@ -132,9 +132,9 @@ client = Contentful::Client.new(
 entry = client.entry('nyancat')
 ```
 
-### Using this SDK with the Preview API
+### Using this library with the Preview API
 
-This SDK can also be used with the Preview API. In order to do so, you need to use the Preview API Access token, available on the same page where you get the Delivery API token, and specify the host of the preview API, such as:
+This library can also be used with the Preview API. In order to do so, you need to use the Preview API Access token, available on the same page where you get the Delivery API token, and specify the host of the preview API, such as:
 
 ```ruby
 require 'contentful'
@@ -168,7 +168,7 @@ For more information, check the [Contentful REST API reference on Authentication
 - [Migrating to 2.x](#migrating-to-2x)
 
 
-To help you get the most out of this SDK, we've prepared all available client configuration options, reference documentation, tutorials and other examples that will help you learn and understand how to use this library.
+To help you get the most out of this library, we've prepared all available client configuration options, reference documentation, tutorials and other examples that will help you learn and understand how to use this library.
 
 ### Configuration
 
@@ -287,7 +287,7 @@ client = Contentful::Client.new(
       <td><code>max_include_resolution_depth</code></td>
       <td><code>20</code></td>
       <td>
-        Maximum amount of levels to resolve includes for SDK entities
+        Maximum amount of levels to resolve includes for library entities
         (this is independent of API-level includes - it represents the maximum depth the include resolution
         tree is allowed to resolved before falling back to <code>Link</code> objects).
         This include resolution strategy is in place in order to avoid having infinite circular recursion on resources with circular dependencies.


### PR DESCRIPTION
For all public CMA and CDA projects, we will replace the terminology `SDK` with `library`
