### PR TITLE
Move Travis CI to travis-ci.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@
     <img src="https://img.shields.io/badge/license-MIT-brightgreen.svg" alt="MIT License" />
   </a>
   &nbsp;
-  <a href="https://travis-ci.org/contentful/contentful.rb">
-    <img src="https://travis-ci.org/contentful/contentful.rb.svg?branch=master" alt="Build Status">
+  <a href="https://app.travis-ci.com/contentful/contentful.rb">
+    <img src="https://app.travis-ci.com/contentful/contentful.rb.svg?branch=master" alt="Build Status">
   </a>
 </p>
 


### PR DESCRIPTION
Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>

Transfer [one on travis-ci.org](https://travis-ci.org/github/contentful/contentful.rb) to [app.travis-ci.com](https://app.travis-ci.com/github/contentful/contentful.rb) like [other repos on Contentful](https://app.travis-ci.com/github/contentful) since .org was shut down on June 15th, 2021.

Results on `tnir/contentful.rb`: https://app.travis-ci.com/github/tnir/contentful.rb/branches