### PR TITLE
Update http.rb version

### DIFF
--- a/contentful.gemspec
+++ b/contentful.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
     gem.add_development_dependency'term-ansicolor', '~> 1.3.0'
     gem.add_development_dependency 'public_suffix', '< 1.5'
   else
-    gem.add_dependency 'http', '> 0.8', '< 5.0'
+    gem.add_dependency 'http', '> 0.8', '< 6.0'
   end
 
   gem.add_dependency 'multi_json', '~> 1'


### PR DESCRIPTION
The HTTP gem has a stable version 5.x (5.0.4 at the time of writing).