### PR TITLE
Fixed an issue where `raw['metadata']` was unexpectedly overwritten

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 ### Fixed
 * Fixed an issue where entry's `raw['fields']` was unexpectedly overwritten by `FieldsResource#raw_with_links` method.
+* Fixed an issue where `raw['metadata']` was unexpectedly overwritten by `BaseResource#hydrate_metadata` method.
 
 ## 2.16.1
 * Removed unncessary files from gem release package.

--- a/lib/contentful/base_resource.rb
+++ b/lib/contentful/base_resource.rb
@@ -98,7 +98,7 @@ module Contentful
     def hydrate_metadata
       result = {}
       raw.fetch('metadata', {}).each do |k, v|
-        v.map! { |tag| build_link(tag) } if k == 'tags'
+        v = v.map { |tag| build_link(tag) } if k == 'tags'
         result[Support.snakify(k, @configuration[:use_camel_case]).to_sym] = v
       end
       result


### PR DESCRIPTION
Fixes #244 