### PR TITLE
fix:[RUBY-101]update specs to match new json parse error messaging

### DIFF
--- a/spec/error_class_spec.rb
+++ b/spec/error_class_spec.rb
@@ -288,7 +288,7 @@ describe Contentful::Error do
       it 'returns the json parser\'s message' do
         uj = Contentful::Response.new raw_fixture('unparsable')
         expect(Contentful::UnparsableJson.new(uj).message).to \
-            include 'unexpected token'
+            include "expected ',' or '}' after object value"
       end
     end
   end

--- a/spec/response_spec.rb
+++ b/spec/response_spec.rb
@@ -50,7 +50,7 @@ describe Contentful::Response do
     end
 
     it 'returns json parser error message for json parse errors' do
-      expect(unparsable_response.error_message).to include 'unexpected token'
+      expect(unparsable_response.error_message).to include "expected ',' or '}' after object value"
     end
 
     it 'returns a ServiceUnavailable error on a 503' do


### PR DESCRIPTION
Two specs were failing because they relied on a specific error message being present when there were JSON parsing errors. The latest Ruby JSON parser has different, more specific, error messaging and so the specs were updated to check accordingly.