### PR TITLE
feat: support http gem 6.x [DX-1170]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## Unreleased
+* Allow `http` gem `6.x` by widening the dependency constraint to `'> 0.8', '< 7.0'`. Resolves [#278](https://github.com/contentful/contentful.rb/issues/278).
+* Adapted error response handling for `http` 6.x: status codes are now coerced to integers for class lookup (`HTTP::Response::Status` no longer inherits from `Delegator`), and the rate-limit reset header is read via `raw.headers[...]` (the `[]` delegator on `HTTP::Response` was removed).
 
 ## 2.19.0
 * Added `http_instrumenter` configuration option to allow instrumenting HTTP requests. [#266](https://github.com/contentful/contentful.rb/pull/266)

--- a/contentful.gemspec
+++ b/contentful.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
     gem.add_development_dependency'term-ansicolor', '~> 1.3.0'
     gem.add_development_dependency 'public_suffix', '< 1.5'
   else
-    gem.add_dependency 'http', '> 0.8', '< 6.0'
+    gem.add_dependency 'http', '> 0.8', '< 7.0'
   end
 
   gem.add_dependency 'multi_json', '~> 1.15'

--- a/lib/contentful/error.rb
+++ b/lib/contentful/error.rb
@@ -149,7 +149,7 @@ module Contentful
 
     # Time until next available request, in seconds.
     def reset_time
-      @reset_time ||= @response.raw[RATE_LIMIT_RESET_HEADER_KEY]
+      @reset_time ||= @response.raw.headers[RATE_LIMIT_RESET_HEADER_KEY]
     end
 
     protected

--- a/lib/contentful/response.rb
+++ b/lib/contentful/response.rb
@@ -58,31 +58,35 @@ module Contentful
       parse_http_error
     end
 
+    def status_code
+      raw.status.to_i
+    end
+
     def valid_http_response?
-      [200, 201].include?(raw.status)
+      [200, 201].include?(status_code)
     end
 
     def service_unavailable_response?
-      @raw.status == 503
+      status_code == 503
     end
 
     def service_unavailable_error
       @status = :error
       @error_message = '503 - Service Unavailable'
-      @object = Error[@raw.status].new(self)
+      @object = Error[status_code].new(self)
     end
 
     def parse_http_error
       @status = :error
-      @object = Error[raw.status].new(self)
+      @object = Error[status_code].new(self)
     end
 
     def invalid_response?
-      [400, 404].include?(raw.status)
+      [400, 404].include?(status_code)
     end
 
     def no_content_response?
-      raw.to_s == '' && raw.status == 204
+      raw.to_s == '' && status_code == 204
     end
 
     def parse_json!


### PR DESCRIPTION
## Summary
- Widen the `http` gem dependency from `< 6.0` to `< 7.0` so consumers can pull in `http` 6.x. Resolves [#278](https://github.com/contentful/contentful.rb/issues/278).
- Adapt error response handling for two `http` 6.0 breaking changes:
  - `HTTP::Response::Status` no longer inherits from `Delegator`, so it no longer behaves like an Integer for hash-key lookup. Coerce `raw.status` to an Integer (`raw.status.to_i`) before passing it to `Contentful::Error[]`.
  - The `[]` delegator on `HTTP::Response` was removed. Read the rate-limit reset header via `raw.headers[...]` instead of `raw[...]`.

## Context
Reported in [contentful.rb#278](https://github.com/contentful/contentful.rb/issues/278) — `http` 6.0 shipped 2026-03-16 (current 6.0.4 as of 2026-05-26) and the `< 6.0` cap was blocking downstream consumers who depend on both `contentful` and another gem requiring `http` >= 6.

The `http` usage in this gem is thin (just `Contentful::Client.get_http`), so the widening is low-risk. The two adapter fixes were caught by the existing spec suite, which now runs cleanly under both `http` 5.x and 6.x.

Tracking: [DX-1170](https://contentful.atlassian.net/browse/DX-1170).

## Test plan
- [x] `bundle exec rspec` passes against `http` 6.0.3 (366 examples, 0 failures, 2 pending)
- [x] `bundle exec rspec` passes against `http` 5.3.1 (366 examples, 0 failures, 2 pending)
- [x] `bundle exec rubocop lib/contentful/response.rb lib/contentful/error.rb` clean
- [ ] CI matrix (Ruby 3.2 / 3.3 / 3.4) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DX-1170]: https://contentful.atlassian.net/browse/DX-1170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR adds support for http gem 6.x by widening the dependency constraint from '< 6.0' to '< 7.0' in contentful.gemspec and adapting the codebase to handle two breaking changes introduced in http 6.0. The changes ensure the contentful gem remains compatible with both http 5.x and 6.x versions.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Widens http gem dependency from '< 6.0' to '< 7.0' in contentful.gemspec to allow downstream consumers depending on both contentful and gems requiring http >= 6</li>

<li>Adds status_code method in response.rb to coerce raw.status to Integer, addressing http 6.0's HTTP::Response::Status no longer inheriting from Delegator</li>

<li>Updates all raw.status references in response.rb to use the new status_code method for consistent Integer comparison in error handling</li>

<li>Changes rate-limit header access in error.rb from raw[RATE_LIMIT_RESET_HEADER_KEY] to raw.headers[RATE_LIMIT_RESET_HEADER_KEY] to work around removed [] delegator in http 6.0</li>

</ul>
</details>

</div>